### PR TITLE
sracat: Adjust Makefile.

### DIFF
--- a/sracat/Makefile
+++ b/sracat/Makefile
@@ -17,8 +17,9 @@ INC = -I. -I$(SRA_PATH)/include
 
 # 1) The order of the libraries in LIBS is important for g++, do not change!
 # 2) g++ requires -lpthread, while clang does not
+# 3) g++ requires -ldl to be specified (last)
 LIBS = -lm -lz -lpthread -L$(SRA_PATH)/lib64 \
-	-lncbi-ngs-c++ -lncbi-ngs -lngs-c++ -lncbi-vdb-static
+	-lncbi-ngs-c++ -lncbi-ngs -lngs-c++ -lncbi-vdb-static -ldl
 	
 .SUFFIXES : .o .cpp .c
 .cpp.o:


### PR DESCRIPTION
HI @jgans I was able to get it to work after adding this small change. For reasons I don't understand, `-ldl` had to be specified last, otherwise I got errors like this

```
c++  -o sracat   sracat.o -lm -lz -ldl -lpthread -L/home/ben/e/sracat-dev/lib64 -lncbi-ngs-c++ -lncbi-ngs -lngs-c++ -lncbi-vdb-static
/usr/bin/ld: /home/ben/e/sracat-dev/lib64/libncbi-vdb-static.a(kfs-sysdll.pic.o): in function `KDyldLoad.isra.0':
sysdll.c:(.text+0x76): undefined reference to `dlopen'
/usr/bin/ld: sysdll.c:(.text+0x91): undefined reference to `dlsym'
/usr/bin/ld: sysdll.c:(.text+0xb1): undefined reference to `dlsym'
/usr/bin/ld: sysdll.c:(.text+0xd6): undefined reference to `dlsym'
/usr/bin/ld: sysdll.c:(.text+0x106): undefined reference to `dlsym'
/usr/bin/ld: sysdll.c:(.text+0x12b): undefined reference to `dlsym'
/usr/bin/ld: /home/ben/e/sracat-dev/lib64/libncbi-vdb-static.a(kfs-sysdll.pic.o):sysdll.c:(.text+0x15e): more undefined references to `dlsym' follow
/usr/bin/ld: /home/ben/e/sracat-dev/lib64/libncbi-vdb-static.a(kfs-sysdll.pic.o): in function `KDyldLoad.isra.0':
sysdll.c:(.text+0x191): undefined reference to `dlerror'
/usr/bin/ld: /home/ben/e/sracat-dev/lib64/libncbi-vdb-static.a(kfs-sysdll.pic.o): in function `KDyldHomeDirectory':
sysdll.c:(.text+0x718): undefined reference to `dladdr'
/usr/bin/ld: /home/ben/e/sracat-dev/lib64/libncbi-vdb-static.a(kfs-sysdll.pic.o): in function `KDylibRelease':
sysdll.c:(.text+0xe49): undefined reference to `dlclose'
/usr/bin/ld: sysdll.c:(.text+0xe69): undefined reference to `dlerror'
/usr/bin/ld: /home/ben/e/sracat-dev/lib64/libncbi-vdb-static.a(kfs-sysdll.pic.o): in function `KSymAddrRelease':
sysdll.c:(.text+0x1421): undefined reference to `dlclose'
/usr/bin/ld: sysdll.c:(.text+0x1434): undefined reference to `dlerror'
/usr/bin/ld: /home/ben/e/sracat-dev/lib64/libncbi-vdb-static.a(kfs-sysdll.pic.o): in function `KDylibSymbol':
sysdll.c:(.text+0x14e5): undefined reference to `dlsym'
/usr/bin/ld: sysdll.c:(.text+0x14ed): undefined reference to `dlerror'
collect2: error: ld returned 1 exit status
make: *** [Makefile:33: sracat] Error 1
```